### PR TITLE
Change version handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ You can use this repository as a GitHub action to test and/or publish your build
 
 Use the `with.args` key to pass in arguments to the builder, to see what arguments are supported you can run the [help](#help) or look in the [builder.sh file](./builder.sh)
 
-To spesify a version of the runner you want to use, set the `with.version` key, this defaults to `dev`.
-
 ### Test action example
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,7 @@ runs:
     - shell: bash
       id: version
       run: |
+        echo "${{ toJson(github) }}"
         input=$(echo ${{ github.action_path }} | cut -d"/" -f8 )
         if [[ "${input}" == "master" ]]; then
           echo "::set-output name=version::dev"

--- a/action.yml
+++ b/action.yml
@@ -5,13 +5,18 @@ inputs:
     description: 'Arguments passed to the builder'
     required: true
     default: '--help'
-  version:
-    description: 'The version of the builder'
-    required: false
-    default: 'dev'
 runs:
   using: "composite"
   steps: 
+    - shell: bash
+      id: version
+      run: |
+        input=$(echo ${{ github.action_path }} | cut -d"/" -f8 )
+        if [[ "${input}" == "master" ]]; then
+          echo "::set-output name=version::dev"
+        else
+          echo "::set-output name=version::$input"
+
     - shell: bash
       id: build
       run: |
@@ -19,8 +24,9 @@ runs:
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
             -v ~/.docker:/root/.docker \
             -v ${{ github.workspace }}:/data \
-            homeassistant/amd64-builder:${{ inputs.version }} \
+            homeassistant/amd64-builder:${{ steps.version.outputs.version }} \
             ${{ inputs.args }}
+
     - shell: bash
       id: verify
       run: docker images

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
       run: |
         input=$(echo "${{ github.action_path }}" | cut -d"/" -f8 )
         if [[ "${input}" == "master" ]] || [[ -z "${input}" ]]; then
-          input="dev"
+          input="latest"
         fi
         echo "::set-output name=version::${input}"
 

--- a/action.yml
+++ b/action.yml
@@ -11,12 +11,11 @@ runs:
     - shell: bash
       id: version
       run: |
-        echo "${{ toJson(github) }}"
-        input=$(echo ${{ github.action_path }} | cut -d"/" -f8 )
-        if [[ "${input}" == "master" ]]; then
-          echo "::set-output name=version::dev"
-        else
-          echo "::set-output name=version::$input"
+        input=$(echo "${{ github.action_path }}" | cut -d"/" -f8 )
+        if [[ "${input}" == "master" ]] || [[ -z "${input}" ]]; then
+          input="dev"
+        fi
+        echo "::set-output name=version::${input}"
 
     - shell: bash
       id: build


### PR DESCRIPTION
- Removes the `version` key for `with`
- Uses the requested action version as the builder version, if `master` it uses the `latest` builder


So with this change:

- `uses: home-assistant/builder@master` will use `homeassistant/amd64-builder:latest` 
- `uses: home-assistant/builder@2020.10.0` will use `homeassistant/amd64-builder:2020.10.0` 