### PR TITLE
Fix custom cache tag parameter retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Build handling
       Disable cache for the build (from latest).
   --self-cache
       Use same tag as cache tag instead latest.
-  --cache-tag
+  --cache-tag <TAG>
       Use a custom tag for the build cache.
   -d, --docker-hub <DOCKER_REPOSITORY>
       Set or overwrite the docker repository.

--- a/builder.sh
+++ b/builder.sh
@@ -103,7 +103,7 @@ Options:
        Disable cache for the build (from latest).
     --self-cache
        Use same tag as cache tag instead latest.
-    --cache-tag
+    --cache-tag <TAG>
        Use a custom tag for the build cache.
     -d, --docker-hub <DOCKER_REPOSITORY>
        Set or overwrite the docker repository.
@@ -755,6 +755,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --cache-tag)
             CUSTOM_CACHE_TAG=$2
+            shift
             ;;
         --release-tag)
             RELEASE_TAG=true


### PR DESCRIPTION
On the use of the new cache tag parameter I noticed that the parameter were not shifted. This PR corrects this.