### PR TITLE
Support Odroid C4 SBC

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -36,6 +36,7 @@ BUILD_ERROR=()
 declare -A BUILD_MACHINE=(
                           [intel-nuc]="amd64" \
                           [odroid-c2]="aarch64" \
+                          [odroid-c4]="aarch64" \
                           [odroid-n2]="aarch64" \
                           [odroid-xu]="armv7" \
                           [qemuarm]="armhf" \


### PR DESCRIPTION
This PR is supplemental to the `operating-system` PR https://github.com/home-assistant/operating-system/pull/926, which adds support for the Odroid C4 SBC.