### PR TITLE
Build before test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,16 +11,27 @@ env:
   GIT_TAG_NAME: dev
 
 jobs:
+  init:
+    name: Initialize build
+    runs-on: ubuntu-latest
+    outputs:
+      architectures: ${{ steps.info.outputs.architectures }}
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+
+    - name: Get information
+      id: info
+      uses: home-assistant/actions/helpers/info@master
+
   publish:
-    name: Publish
+    name: Publish builder
+    needs: init
     runs-on: ubuntu-latest
     strategy:
       fail-fast: False
       matrix:
-        architecture:
-          - aarch64
-          - amd64
-          - armv7
+        architecture: ${{ fromJson(needs.init.outputs.architectures) }}
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,17 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@v2
 
-    - name: Test builder
-      uses: ./ # This is self-refrencing
+    - name: Build the builder
+      uses: home-assistant/builder@master
+      with:
+        args: |
+          --test \
+          --amd64 \
+          --target /data \
+          --generic latest
+
+    - name: Test ${{ matrix.architecture }} builder
+      uses: ./
       with:
         args: |
           --test \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,16 +4,27 @@ on:
   pull_request:
 
 jobs:
+  init:
+    name: Initialize build
+    runs-on: ubuntu-latest
+    outputs:
+      architectures: ${{ steps.info.outputs.architectures }}
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+
+    - name: Get information
+      id: info
+      uses: home-assistant/actions/helpers/info@master
+
   build:
     name: Test action build
+    needs: init
     runs-on: ubuntu-latest
     strategy:
       fail-fast: False
       matrix:
-        architecture:
-          - aarch64
-          - amd64
-          - armv7
+        architecture: ${{ fromJson(needs.init.outputs.architectures) }}
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v2


### PR DESCRIPTION
Since the action is pulling down lastest, we are actually not testing changes to the Dockerfile of the builder script.

This will (for PR's), build the builder using latest, which will produce a new builder (with latest), that will be used to do the test build,