### PR TITLE
Filter output of docker images

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,15 @@ runs:
         echo "::set-output name=version::${input}"
 
     - shell: bash
+      run: docker pull homeassistant/amd64-builder:${{ steps.version.outputs.version }}
+
+    - shell: bash
+      id: builder
+      run: |
+        builder=$(docker images homeassistant/amd64-builder:${{ steps.version.outputs.version }} -q)
+        echo "::set-output name=id::$builder"
+
+    - shell: bash
       id: build
       run: |
         docker run --rm --privileged \
@@ -30,7 +39,9 @@ runs:
     - shell: bash
       id: verify
       run: |
-        docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" --filter label=io.hass.version
+        docker images \
+          --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" \
+          --filter since=${{ steps.builder.outputs.id }}
 branding:
   icon: 'home'  
   color: 'blue'

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,8 @@ runs:
       run: |
         docker images \
           --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" \
+          --filter reference="*/*" \
+          --filter reference="*" \
           --filter since=${{ steps.builder.outputs.id }}
 branding:
   icon: 'home'  

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,8 @@ runs:
 
     - shell: bash
       id: verify
-      run: docker images
+      run: |
+        docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" --filter label=io.hass.version
 branding:
   icon: 'home'  
   color: 'blue'


### PR DESCRIPTION
Current output:

```
REPOSITORY                                           TAG                 IMAGE ID            CREATED             SIZE
homeassistant/amd64-builder                          latest              e3cebba27d39        1 second ago        716MB
homeassistant/amd64-base-ubuntu                      18.04               5280d4156ab4        18 hours ago        85.3MB
homeassistant/amd64-builder                          <none>              fad53788139a        24 hours ago        710MB
node                                                 10                  56387899b840        2 weeks ago         911MB
node                                                 12                  1f560ce4ce7e        2 weeks ago         918MB
buildpack-deps                                       stretch             b39de549c36a        2 weeks ago         835MB
buildpack-deps                                       buster              f3f98451c17d        2 weeks ago         804MB
debian                                               9                   c4ccba324c9c        2 weeks ago         101MB
debian                                               8                   091099bf65ad        2 weeks ago         129MB
node                                                 12-alpine           d8b74300d554        2 weeks ago         89.6MB
node                                                 10-alpine           57006130ce4b        3 weeks ago         83.5MB
ubuntu                                               14.04               df043b4f0cf1        5 weeks ago         197MB
jekyll/builder                                       latest              a8007cad4069        7 weeks ago         677MB
alpine                                               3.9                 78a2ce922f86        6 months ago        5.55MB
alpine                                               3.10                be4e4bea2c2e        6 months ago        5.58MB
alpine                                               3.8                 c8bccc0af957        9 months ago        4.41MB
alpine                                               3.7                 6d1ef012b567        20 months ago       4.21MB
mcr.microsoft.com/azure-pipelines/node8-typescript   latest              9a948d360778        2 years ago         595MB
```

With this change:
```
REPOSITORY:TAG                                                         SIZE
homeassistant/amd64-builder:ae458893bc149fd8bd8a677f723bdbead40cfa87   716MB
homeassistant/amd64-builder:latest                                     716MB
homeassistant/amd64-base-ubuntu:18.04                                  85.3MB
```