### PR TITLE
Allow --version to overwrite addon version

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -440,7 +440,6 @@ function build_addon() {
     local build_arch=$1
 
     local build_from=""
-    local version=""
     local image=""
     local repository=""
     local raw_image=""
@@ -474,9 +473,13 @@ function build_addon() {
     name="$(jq --raw-output '.name // empty' "$TARGET/config.json" | sed "s/'//g")"
     description="$(jq --raw-output '.description // empty' "$TARGET/config.json" | sed "s/'//g")"
     url="$(jq --raw-output '.url // empty' "$TARGET/config.json")"
-    version="$(jq --raw-output '.version' "$TARGET/config.json")"
     raw_image="$(jq --raw-output '.image // empty' "$TARGET/config.json")"
     mapfile -t supported_arch < <(jq --raw-output '.arch // empty' "$TARGET/config.json")
+    
+    # Read version from config.json when empty
+    if [ -z "$VERSION" ]
+    	version="$(jq --raw-output '.version' "$TARGET/config.json")"
+    fi
 
     # Check arch
     if [[ ! ${supported_arch[*]} =~ ${build_arch} ]]; then
@@ -799,6 +802,8 @@ while [[ $# -gt 0 ]]; do
             ;;
         --addon)
             BUILD_TYPE="addon"
+            VERSION=$2
+            shift
             ;;
         --base)
             BUILD_TYPE="base"

--- a/builder.sh
+++ b/builder.sh
@@ -440,11 +440,11 @@ function build_addon() {
     local build_arch=$1
 
     local build_from=""
+    local version=""
     local image=""
     local repository=""
     local raw_image=""
     local name=""
-    local version=""
     local description=""
     local url=""
     local args=""

--- a/builder.sh
+++ b/builder.sh
@@ -444,6 +444,7 @@ function build_addon() {
     local repository=""
     local raw_image=""
     local name=""
+    local version=""
     local description=""
     local url=""
     local args=""
@@ -476,8 +477,10 @@ function build_addon() {
     raw_image="$(jq --raw-output '.image // empty' "$TARGET/config.json")"
     mapfile -t supported_arch < <(jq --raw-output '.arch // empty' "$TARGET/config.json")
     
-    # Read version from config.json when empty
-    if [ -z "$VERSION" ]; then
+    # Read version from config.json when VERSION is not set
+    if [ -n "$VERSION" ]; then
+    	version="$VERSION"
+    else
     	version="$(jq --raw-output '.version' "$TARGET/config.json")"
     fi
 

--- a/builder.sh
+++ b/builder.sh
@@ -802,8 +802,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --addon)
             BUILD_TYPE="addon"
-            VERSION=$2
-            shift
             ;;
         --base)
             BUILD_TYPE="base"

--- a/builder.sh
+++ b/builder.sh
@@ -477,7 +477,7 @@ function build_addon() {
     mapfile -t supported_arch < <(jq --raw-output '.arch // empty' "$TARGET/config.json")
     
     # Read version from config.json when empty
-    if [ -z "$VERSION" ]
+    if [ -z "$VERSION" ]; then
     	version="$(jq --raw-output '.version' "$TARGET/config.json")"
     fi
 


### PR DESCRIPTION
### Goal
Allow to set the build version for add-ons via the --version or -v parameter.

### Use-case
Using the GitHub actions, I want to be able to use different actions for different purposes, and different results. For example:
- Action 1 builds and uploads the addon release docker files. This is currently possible
- Action 2 builds a dev/edge docker image that is using a specific tag/version which is different to the version of the stable addon, and which is not latest. 

### Change
1. Don't set a local version variable when building an addon
2. Read the version from config.json only when global version variable is empty (e.g. when not set, default)

### desired example config
```
- name: Publish
  uses: home-assistant/builder@master
  with:
   args: |
    --all \
    --target /data \
    --version test \
    --docker-hub userspace-name
```