### PR TITLE
Add creating multi-arch manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Build handling
       Password to login into docker with
   --no-crossbuild-cleanup
       Don't cleanup the crosscompile feature (for multiple builds)
+    --multi-arch <IMAGENAME>
+       Create multiarch manifest (only for 'generic' build)
+       (Need Docker cli with experimental cli features enabled)
 
   Use the host docker socket if mapped into container:
       /var/run/docker.sock

--- a/builder.sh
+++ b/builder.sh
@@ -230,7 +230,7 @@ function run_build() {
     if [ -n "$DOCKER_HUB" ]; then repository="$DOCKER_HUB"; fi
     if [ -n "$IMAGE" ]; then image="$IMAGE"; fi
 
-    echo $repository >$MULTIARCH_TMP_REPO
+    echo "$repository" >$MULTIARCH_TMP_REPO
 
     # Replace {arch} with build arch for image
     # shellcheck disable=SC1117
@@ -685,11 +685,14 @@ function extract_machine_build() {
 
 function create_multiarch_manifest() {
     local docker_amend=()
-    local docker_manifest="$(cat $MULTIARCH_TMP_REPO)/$DOCKER_MULTIARCH_IMAGE:$VERSION"
+    local docker_manifest=""
 
-    for image in $(cat $MULTIARCH_TMP_IMAGES); do
+    docker_manifest="$(cat $MULTIARCH_TMP_REPO)/$DOCKER_MULTIARCH_IMAGE:$VERSION"
+
+    while read -r image
+    do
         docker_amend+=("--amend" "$image")
-    done
+    done < $MULTIARCH_TMP_IMAGES
 
     bashio::log.info "Create multiarch manifest $docker_manifest"
     docker manifest create "$docker_manifest" \


### PR DESCRIPTION
This PR will add another option `--multi-arch <IMAGENAME>` which will create a multi-arch manifest to combine same images for different architectures - example:

- command:
`docker run --rm --privileged -v /root/.docker:/root/.docker -v /var/run/docker.sock:/var/run/docker.sock mib85/homeassistant-builder:multiarch --all --multi-arch homeassistant --version synology-dsm_fix-camera-update --self-cache --generic synology-dsm_fix-camera-update --no-latest -r https://github.com/mib1185/homeassistant-core -b synology-dsm_fix-camera-update --docker-hub mib85 --docker-user ************ --docker-password ************`

- result:

![image](https://user-images.githubusercontent.com/35783820/101094170-40125880-35bc-11eb-9984-fd00bea3fad1.png)
---
![image](https://user-images.githubusercontent.com/35783820/101094038-0e00f680-35bc-11eb-8015-cb0cd05d506a.png)

