### PR TITLE
Add support for generic-x86-64 machine

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -34,6 +34,7 @@ BUILD_TYPE="addon"
 BUILD_TASKS=()
 BUILD_ERROR=()
 declare -A BUILD_MACHINE=(
+                          [generic-x86-64]="amd64" \
                           [intel-nuc]="amd64" \
                           [odroid-c2]="aarch64" \
                           [odroid-c4]="aarch64" \


### PR DESCRIPTION
The Intel NUC machine runs on most UEFI capable x86-64 machines today.
Lets start a new machine generic-x86-64 which will replace intel-nuc
over time.