### PR TITLE
Fix call to removed function in trap

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -747,8 +747,6 @@ function codenotary_validate() {
 
 function error_handling() {
     stop_docker
-    clean_crosscompile
-
     bashio::exit.nok "Abort by User"
 }
 trap 'error_handling' SIGINT SIGTERM


### PR DESCRIPTION
The trap method calls `clean_crosscompile`, which has been removed from the builder.

Fixes #86