### PR TITLE
Add support for khadas-vim3 machine

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -40,6 +40,7 @@ BUILD_ERROR=()
 declare -A BUILD_MACHINE=(
                           [generic-x86-64]="amd64" \
                           [intel-nuc]="amd64" \
+                          [khadas-vim3]="aarch64" \
                           [odroid-c2]="aarch64" \
                           [odroid-c4]="aarch64" \
                           [odroid-n2]="aarch64" \


### PR DESCRIPTION
Add Khadas VIM3 machine, based on a Amlogic A311D with Cortex-A53/A73.