### PR TITLE
Add support for generic-aarch64 machine

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -38,6 +38,7 @@ BUILD_TYPE="addon"
 BUILD_TASKS=()
 BUILD_ERROR=()
 declare -A BUILD_MACHINE=(
+                          [generic-aarch64]="aarch64" \
                           [generic-x86-64]="amd64" \
                           [intel-nuc]="amd64" \
                           [khadas-vim3]="aarch64" \


### PR DESCRIPTION
Support generic 64-bit ARM machines which are capable booting in UEFI
mode.