### PR TITLE
Remove shellcheck package from devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,0 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.163.1/containers/alpine/.devcontainer/base.Dockerfile
-
-# [Choice] Alpine version: 3.13, 3.12, 3.11, 3.10
-ARG VARIANT="3.13"
-FROM mcr.microsoft.com/vscode/devcontainers/base:0-alpine-${VARIANT}
-
-# ** [Optional] Uncomment this section to install additional packages. **
-RUN apk update \
-     && apk add --no-cache shellcheck

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,6 @@
 {
   "name": "Alpine",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "args": { "VARIANT": "3.13" }
-  },
+  "image": "mcr.microsoft.com/vscode/devcontainers/base:0-alpine-3.13",
   "settings": {
     "terminal.integrated.shell.linux": "/bin/ash",
     "shellcheck.enable": true,


### PR DESCRIPTION
[Shellcheck package](https://pkgs.alpinelinux.org/packages?name=shellcheck&branch=v3.13) is only available for alpine with `x86_64` architecture. Devcontainer simply fails to start on `aarch64` or any other architecture. It's also not really needed as the shellcheck extension works fine without it. Removing it from the devcontainer Dockerfile.

Also since that was the only customization in the devcontainer Dockerfile, just removed the Dockerfile entirely and set it to use the ms image directly.