### PR TITLE
Better host support

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -436,8 +436,8 @@ function build_base() {
         bashio::log.error "Can't find the image tag on build.json"
         return 1
     fi
-    repository="$(echo "${raw_image}" | cut -f 1 -d '/')"
-    image="$(echo "${raw_image}" | cut -f 2 -d '/')"
+    repository="${raw_image%/*}"
+    image="${raw_image##*/}"
 
     # Additional build args
     if bashio::var.has_value "${args}"; then
@@ -535,8 +535,8 @@ function build_addon() {
 
     # Read data from image
     if [ -n "$raw_image" ]; then
-        repository="$(echo "$raw_image" | cut -f 1 -d '/')"
-        image="$(echo "$raw_image" | cut -f 2 -d '/')"
+        repository="${raw_image%/*}"
+        image="${raw_image##*/}"
     fi
 
     # Set additional labels
@@ -654,8 +654,8 @@ function build_machine() {
         docker_cli+=("--file" "${TARGET}/${build_machine}")
     fi
 
-    repository="$(echo "${raw_image}" | cut -f 1 -d '/')"
-    image="$(echo "${raw_image}" | cut -f 2 -d '/')"
+    repository="${raw_image%/*}"
+    image="${raw_image##*/}"
 
     # Replace {machine} with build machine for image
     # shellcheck disable=SC1117


### PR DESCRIPTION
With this change you can now set the image to use other docker registries, not just dockerhub.

I.e. now using `image: gchr.io/me/addon` will work.