### PR TITLE
Fix get branch (last part from path) to correct behavior in case of different path lengths

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
     - shell: bash
       id: version
       run: |
-        input=$(echo "${{ github.action_path }}" | cut -d"/" -f8 )
+        input=$(echo "${{ github.action_path }}" | rev | cut -d"/" -f1 | rev)
         if [[ "${input}" == "master" ]] || [[ -z "${input}" ]]; then
           input="latest"
         fi


### PR DESCRIPTION
Fix get version (last part from repository path) to correct behavior in case of different path lengths.