### PR TITLE
Bind mount /mnt for temporary build artifacts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,7 @@ runs:
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
             -v ~/.docker:/root/.docker \
             -v ${{ github.workspace }}:/data \
+            -v /mnt:/mnt \
             --env-file "${{ github.action_path }}/env_file" \
             ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }} \
             ${{ inputs.args }}


### PR DESCRIPTION
The new GitHub Action hosted runners have less space on /. For some add-ons this can be problematic. Unfortunately it is not straight forward to use /mnt as Docker data root. Instead just mount /mnt inside the container so add-on Dockerfiles can use that location for temporary build files.