### PR TITLE
Use default cosign version v2.2.3 provided by cosign-installer action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Install Cosign
       uses: sigstore/cosign-installer@v3.4.0
       with:
-        cosign-release: "v2.0.2"
+        cosign-release: "v2.2.3"
 
     - shell: bash
       id: version

--- a/build.yaml
+++ b/build.yaml
@@ -10,7 +10,7 @@ cosign:
   identity: https://github.com/home-assistant/builder/.*
 args:
   YQ_VERSION: "v4.13.2"
-  COSIGN_VERSION: "2.0.2"
+  COSIGN_VERSION: "2.2.3"
 labels:
   io.hass.type: builder
   org.opencontainers.image.title: "Home Assistant Builder"


### PR DESCRIPTION
Move to the default cosign version what the latest cosign-installer would provide by default. Still explicitly select the version to make sure it stays in sync with the version installed in the builder.