### PR TITLE
Disable cosign signature verification

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5,9 +5,6 @@ build_from:
   armhf: "ghcr.io/home-assistant/armhf-base:3.18"
   amd64: "ghcr.io/home-assistant/amd64-base:3.18"
   i386: "ghcr.io/home-assistant/i386-base:3.18"
-cosign:
-  base_identity: https://github.com/home-assistant/docker-base/.*
-  identity: https://github.com/home-assistant/builder/.*
 args:
   YQ_VERSION: "v4.13.2"
   COSIGN_VERSION: "2.2.3"


### PR DESCRIPTION
The current version of cosign deployed in the latest builder doesn't work with the currently deployed TUF Trust Root on the sigstore servers (see also https://blog.sigstore.dev/tuf-root-update/).

Remove the cosign identity information to temporarily disable signature verification. This allows to build a new release with a newer cosign.