### PR TITLE
Disable cosign signing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,5 +57,4 @@ jobs:
           args: |
             --${{ matrix.architecture }} \
             --target /data \
-            --cosign \
             --generic $GIT_TAG_NAME


### PR DESCRIPTION
Since the current builder contains a non-working cosign version, we have to disable signing the builder temporarily as well. This will lead to a build which is unsigned, but will allow us to build another signed builder, and finally reenable signature checking as well.