### PR TITLE
Disable cosign verification by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,10 +25,6 @@ runs:
     - shell: bash
       run: |
         docker pull ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }}
-        cosign verify \
-          --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity-regexp https://github.com/home-assistant/builder/.* \
-          ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }}
 
     - shell: bash
       id: builder


### PR DESCRIPTION
Since we can't sign the current builder, we also need to disable verification of it's signature. This avoids another chicken-egg-problem.