### PR TITLE
Reenable cosign verification

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ runs:
     - shell: bash
       run: |
         docker pull ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }}
+        cosign verify \
+          --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+          --certificate-identity-regexp https://github.com/home-assistant/builder/.* \
+          ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }}
 
     - shell: bash
       id: builder

--- a/build.yaml
+++ b/build.yaml
@@ -5,6 +5,9 @@ build_from:
   armhf: "ghcr.io/home-assistant/armhf-base:3.18"
   amd64: "ghcr.io/home-assistant/amd64-base:3.18"
   i386: "ghcr.io/home-assistant/i386-base:3.18"
+cosign:
+  base_identity: https://github.com/home-assistant/docker-base/.*
+  identity: https://github.com/home-assistant/builder/.*
 args:
   YQ_VERSION: "v4.13.2"
   COSIGN_VERSION: "2.2.3"


### PR DESCRIPTION
With 2024.03.4 we have a working and signed version of the builder again. We can reenable cosign verification in the builder as well as in the builder CI.