### PR TITLE
Update get-tag GitHub Action to v2.1.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
-      - uses: olegtarasov/get-tag@v2.1
+      - uses: olegtarasov/get-tag@v2.1.3
         if: github.event_name == 'release'
         name: Set tag envronment variable
 


### PR DESCRIPTION
This resolves a couple of warnings in GitHub Actions on release.