### PR TITLE
bug fix issue 209 default Alpine version 3.13->3.16

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Alpine",
-  "image": "mcr.microsoft.com/vscode/devcontainers/base:0-alpine-3.13",
+  "image": "mcr.microsoft.com/vscode/devcontainers/base:0-alpine-3.16",
   "settings": {
     "terminal.integrated.shell.linux": "/bin/ash",
     "shellcheck.enable": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Alpine",
-  "image": "mcr.microsoft.com/vscode/devcontainers/base:0-alpine-3.16",
+  "image": "mcr.microsoft.com/vscode/devcontainers/base:0-alpine-3.20",
   "settings": {
     "terminal.integrated.shell.linux": "/bin/ash",
     "shellcheck.enable": true,


### PR DESCRIPTION
vs code now need 3.16+ Alpine linux as container image. the default image version need to be updated