### PR TITLE
Disable cosign verification of the builder

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5,9 +5,6 @@ build_from:
   armhf: "ghcr.io/home-assistant/armhf-base:3.18"
   amd64: "ghcr.io/home-assistant/amd64-base:3.18"
   i386: "ghcr.io/home-assistant/i386-base:3.18"
-cosign:
-  base_identity: https://github.com/home-assistant/docker-base/.*
-  identity: https://github.com/home-assistant/builder/.*
 args:
   YQ_VERSION: "v4.13.2"
   COSIGN_VERSION: "2.2.3"


### PR DESCRIPTION
The currently published builder seems to be not correctly signed. Disable cosign verification to allow another builder build.

Related-to: #212