### PR TITLE
Use released versions of the builder

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish ${{ matrix.architecture }} builder
-        uses: ./
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             --${{ matrix.architecture }} \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build the builder
-        uses: home-assistant/builder@master
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             --test \


### PR DESCRIPTION
To build or test the builder, let's use a released version of the builder. This allows to fix the builder in case something got broken with a PR.