### PR TITLE
Trust git repositories in builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN \
     else \
         exit 1; \
     fi \
+    && git config --global --add safe.directory "*" \
     && chmod +x /usr/bin/yq \
     && chmod +x /usr/bin/cosign
 


### PR DESCRIPTION
With the Alpine 3.20 upgrade git no longer by default trust git repositories. This leads to a warning by Dockers BuildKit:

WARNING: current commit information was not captured by the build: failed to read current commit information with git rev-parse --is-inside-work-tree

Avoid this warning by trusting all git repositories like before the Alpine 3.20 upgrade.

It probably would be better if we can simply trust only the passed data directory, but the git repository might be higher up then the passed path. Also the data directory could be something other than /data.