### PR TITLE
Use manifest digest for signing

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -389,7 +389,8 @@ function run_build() {
     fi
 
     # Singing image (cosign)
-    cosign_sign "${repository}/${image}:${version}"
+    image_id=$(docker inspect --format='{{index .RepoDigests 0}}' "${repository}/${image}:${version}")
+    cosign_sign "${image_id}"
 }
 
 function convert_to_json() {

--- a/builder.sh
+++ b/builder.sh
@@ -386,11 +386,13 @@ function run_build() {
                 fi
             done
         done
-    fi
 
-    # Singing image (cosign)
-    image_id=$(docker inspect --format='{{index .RepoDigests 0}}' "${repository}/${image}:${version}")
-    cosign_sign "${image_id}"
+        # Singing image (cosign)
+        if bashio::var.true "${COSIGN}"; then
+            image_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${repository}/${image}:${version}")
+            cosign_sign "${image_digest}"
+        fi
+    fi
 }
 
 function convert_to_json() {
@@ -756,10 +758,6 @@ function cosign_sign() {
     local image=$1
 
     local success=false
-
-    if bashio::var.false "${DOCKER_PUSH}" || bashio::var.false "${COSIGN}"; then
-        return 0
-    fi
 
     for j in {1..6}; do
         if cosign sign --yes "${image}"; then


### PR DESCRIPTION
Instead of using the image name and tag, use the image name and the manifest sha256. This allows to verify the image sha256 in logs etc. and gets rid of the following warning from cosign:

```
WARNING: Image reference ghcr.io/home-assistant/amd64-builder:dev uses a tag, not a digest, to identify the image to sign.
```