### PR TITLE
Make sure builder image is pulled by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
             --${{ matrix.architecture }} \
             --target /data \
             --generic ${{ github.sha }}
-          no-pull: true
+          no-pull: "true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
             --${{ matrix.architecture }} \
             --target /data \
             --generic ${{ github.sha }}
-          no-pull: "true"
+          pull: "false"

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   no-pull:
     description: "Do not pull the latest version of builder (for testing)"
     required: false
-    default: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -27,7 +27,7 @@ runs:
         echo "version=${input}" >> "$GITHUB_OUTPUT"
 
     - shell: bash
-      if: ${{ inputs.no-pull == true }}
+      if: ${{ inputs.no-pull == "false" }}
       run: |
         docker pull ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }}
         cosign verify \

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
         echo "version=${input}" >> "$GITHUB_OUTPUT"
 
     - shell: bash
-      if: ${{ inputs.no-pull == "false" }}
+      if: ${{ inputs.no-pull == 'false' }}
       run: |
         docker pull ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }}
         cosign verify \

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,10 @@ inputs:
     description: "Arguments passed to the builder"
     required: true
     default: "--help"
-  no-pull:
+  pull:
     description: "Do not pull the latest version of builder (for testing)"
     required: false
-    default: "false"
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -27,7 +27,7 @@ runs:
         echo "version=${input}" >> "$GITHUB_OUTPUT"
 
     - shell: bash
-      if: ${{ inputs.no-pull == 'false' }}
+      if: ${{ inputs.pull == 'true' }}
       run: |
         docker pull ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }}
         cosign verify \

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
     default: "--help"
   pull:
-    description: "Do not pull the latest version of builder (for testing)"
+    description: "Pull the latest version of builder (set to `false` for testing)"
     required: false
     default: "true"
 runs:


### PR DESCRIPTION
Correctly pull the image by default.

The if expression was really wrong. This hasn't been noticed in #214 since the comparison with true == "true" indeed lead to the step not being executed. The GitHub Action syntax doesn't support boolean inputs. Make this explicit using strings.