### PR TITLE
Disable ASLR to work around QEMU aarch64 issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ runs:
       run: |
         env > "${{ github.action_path }}/env_file"
         sed -i "/\(HOME\|TERM\|PWD\|HOSTNAME\|PATH\|SHLVL\|USER\|GOROOT\)/d" "${{ github.action_path }}/env_file"
+        # Work around QEMU aarch64 bugs
+        # https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2613567455
+        sudo sysctl kernel.randomize_va_space=0
 
         docker run --rm --privileged \
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
@@ -54,6 +57,8 @@ runs:
             --env-file "${{ github.action_path }}/env_file" \
             ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }} \
             ${{ inputs.args }}
+
+        sudo sysctl kernel.randomize_va_space=2
 
     - shell: bash
       id: verify


### PR DESCRIPTION
It seems that QEMU and Address Space Layout Randomization do not work well toghether currently. Linux kernel security hardening efforts which make ASLR more random seem to cause SEGFAULTs randomly when building things for aarch64.

It seems that the QEMU for aarch64 made assumptions about how the memory layout is laid out, and/or has bugs in the implementation which are exarbated by the new ASLR scheme. In any case, disabling ASLR during build time avvoids hitting the QEMU bugs.