### PR TITLE
Make builder image arch selectible

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: "Pull the latest version of builder (set to `false` for testing)"
     required: false
     default: "true"
+  image:
+    description: "Define the builder image archictecture (default: amd64)"
+    required: false
+    default: "amd64"
 runs:
   using: "composite"
   steps:
@@ -29,16 +33,16 @@ runs:
     - shell: bash
       if: ${{ inputs.pull == 'true' }}
       run: |
-        docker pull ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }}
+        docker pull ghcr.io/home-assistant/${{ inputs.image }}-builder:${{ steps.version.outputs.version }}
         cosign verify \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
           --certificate-identity-regexp https://github.com/home-assistant/builder/.* \
-          ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }}
+          ghcr.io/home-assistant/${{ inputs.image }}-builder:${{ steps.version.outputs.version }}
 
     - shell: bash
       id: builder
       run: |
-        builder=$(docker images ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }} -q)
+        builder=$(docker images ghcr.io/home-assistant/${{ inputs.image }}-builder:${{ steps.version.outputs.version }} -q)
         echo "id=$builder" >> "$GITHUB_OUTPUT"
 
     - shell: bash
@@ -52,7 +56,7 @@ runs:
             -v ~/.docker:/root/.docker \
             -v ${{ github.workspace }}:/data \
             --env-file "${{ github.action_path }}/env_file" \
-            ghcr.io/home-assistant/amd64-builder:${{ steps.version.outputs.version }} \
+            ghcr.io/home-assistant/${{ inputs.image }}-builder:${{ steps.version.outputs.version }} \
             ${{ inputs.args }}
 
     - shell: bash


### PR DESCRIPTION
With this we can use the home-assistant/builder action also on the new arm runners by passing `image: aarch64` when running on `ubuntu-24.04-arm` - example https://github.com/mib1185/ha-addon-syslog/pull/19
Maybe we could also auto-detect the arch of the runner, but I didn't find a reliable way to determine the runners architecture.