### PR TITLE
Update to cosign v2.4.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Install Cosign
       uses: sigstore/cosign-installer@v3.8.1
       with:
-        cosign-release: "v2.4.0"
+        cosign-release: "v2.4.3"
 
     - shell: bash
       id: version

--- a/build.yaml
+++ b/build.yaml
@@ -10,7 +10,7 @@ cosign:
   identity: https://github.com/home-assistant/builder/.*
 args:
   YQ_VERSION: "v4.13.2"
-  COSIGN_VERSION: "2.4.0"
+  COSIGN_VERSION: "2.4.3"
 labels:
   io.hass.type: builder
   org.opencontainers.image.title: "Home Assistant Builder"


### PR DESCRIPTION
Keep builder up-to-date with latest cosign.

Changelogs:
- cosign [v2.4.1](https://github.com/sigstore/cosign/releases/tag/v2.4.1)
- cosign [v2.4.2](https://github.com/sigstore/cosign/releases/tag/v2.4.2)
- cosign [v2.4.3](https://github.com/sigstore/cosign/releases/tag/v2.4.3)