### PR TITLE
Use ghcr.io as default registry for base image/instructions

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -63,8 +63,8 @@ declare -A BUILD_MACHINE=(
 
 function print_help() {
     cat << EOF
-Hass.io build-env for ecosystem:
-docker run --rm homeassistant/{arch}-builder:latest [options]
+Home Assistant ecosystem build utility:
+docker run --rm ghcr.io/home-assistant/{arch}-builder:latest [options]
 
 Options:
   -h, --help
@@ -529,7 +529,7 @@ function build_addon() {
     # Set defaults build things
     if [ -z "$build_from" ]; then
         bashio::log.info "No build information or from not provided. Using default base image."
-        build_from="homeassistant/${build_arch}-base:latest"
+        build_from="ghcr.io/home-assistant/${build_arch}-base:latest"
     fi
 
     # Additional build args


### PR DESCRIPTION
Currently the instructions and default base image still point to Docker Hub. The respective images are not up-to-date on Docker Hub. Switch to use the GitHub container registry instead.