### PR TITLE
Update README with migration guide for deprecated action

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ The `home-assistant/builder` action is deprecated and no longer maintained, the 
 
 ### Migration Guide
 
-Please refer to the [Migrating app builds to Docker BuildKit blog post](https://developers.home-assistant.io/blog/2026/04/02/builder-migration/) for the migration process.
+Please refer to the [Migrating app builds to Docker BuildKit](https://developers.home-assistant.io/blog/2026/04/02/builder-migration/) for the migration process.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Verifies Cosign signatures on container images with up to 5 retries and exponent
 
 The following example workflow builds multi-arch container images when a GitHub release is published. It prepares a build matrix, builds per-architecture images in parallel (e.g., `ghcr.io/owner/amd64-my-image`, `ghcr.io/owner/aarch64-my-image`), and then combines them into a single multi-arch manifest (`ghcr.io/owner/my-image`).
 
+Note that the workflow below works also for `push` targets in case you want to build and publish an image on every git push.
+
 _Note: Replace `[version]` with the desired tag from the [releases](https://github.com/home-assistant/builder/releases) page._
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -106,3 +106,7 @@ jobs:
 ## Legacy `home-assistant/builder` action
 
 The `home-assistant/builder` action is deprecated and no longer maintained, the last official release was [2026.02.1](https://github.com/home-assistant/builder/blob/2026.02.1/README.md). If you came here because you see the warning in your action, migrate to the new actions above. We will remove the `home-assistant/builder` action soon, which will break your GitHub action if it is still using `home-assistant/builder@master` at that time.
+
+### Migration Guide
+
+Please refer to the [Migrating app builds to Docker BuildKit blog post](https://developers.home-assistant.io/blog/2026/04/02/builder-migration/) for the migration process.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ Verifies Cosign signatures on container images with up to 5 retries and exponent
 
 The following example workflow builds multi-arch container images when a GitHub release is published. It prepares a build matrix, builds per-architecture images in parallel (e.g., `ghcr.io/owner/amd64-my-image`, `ghcr.io/owner/aarch64-my-image`), and then combines them into a single multi-arch manifest (`ghcr.io/owner/my-image`).
 
-Note that the workflow below works also for `push` targets in case you want to build and publish an image on every git push.
+> 📝 Replace `[version]` with the desired tag from the [releases](https://github.com/home-assistant/builder/releases) page.
 
-_Note: Replace `[version]` with the desired tag from the [releases](https://github.com/home-assistant/builder/releases) page._
+> 📝 This workflow works also for `push` triggers in case you want to build and publish an image on every git push 
+> but you may want to change the `image-tags` because on `push` triggers the `${{ github.event.release.tag_name }}`
+> will expand to an empty string.
+
 
 ```yaml
 name: Build
@@ -111,4 +114,4 @@ The `home-assistant/builder` action is deprecated and no longer maintained, the 
 
 ### Migration Guide
 
-Please refer to the [Migrating app builds to Docker BuildKit](https://developers.home-assistant.io/blog/2026/04/02/builder-migration/) for the migration process.
+Please refer to the [Migrating app builds to Docker BuildKit](https://developers.home-assistant.io/blog/2026/04/02/builder-migration/) blog post for the migration process.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Verifies Cosign signatures on container images with up to 5 retries and exponent
 
 The following example workflow builds multi-arch container images when a GitHub release is published. It prepares a build matrix, builds per-architecture images in parallel (e.g., `ghcr.io/owner/amd64-my-image`, `ghcr.io/owner/aarch64-my-image`), and then combines them into a single multi-arch manifest (`ghcr.io/owner/my-image`).
 
-> 📝 Replace `[version]` with the desired tag from the [releases](https://github.com/home-assistant/builder/releases) page.
+> [!NOTE]
+> Replace `[version]` with the desired tag from the [releases](https://github.com/home-assistant/builder/releases) page.
 
-> 📝 This workflow works also for `push` triggers in case you want to build and publish an image on every git push 
-> but you may want to change the `image-tags` because on `push` triggers the `${{ github.event.release.tag_name }}`
-> will expand to an empty string.
+> [!NOTE]
+> This workflow also supports `push` triggers to build and publish an image on every Git push. In that case, update `image-tags` and `version`, because `${{ github.event.release.tag_name }}` expands to an empty string for `push` events.
 
 
 ```yaml


### PR DESCRIPTION
Added migration guide for deprecated home-assistant/builder action.